### PR TITLE
Remove cohesion gem local path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'jquery-rails'
 gem 'cobweb'
 gem 'resque'
 
-gem 'cohesion', :path => "/Users/stewartmckee/code/cohesion"
+gem 'cohesion'
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-PATH
-  remote: /Users/stewartmckee/code/cohesion
-  specs:
-    cohesion (0.0.3)
-      cobweb
-      ptools
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -35,63 +28,63 @@ GEM
     activesupport (3.2.11)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.3.2)
-    ansi (1.4.3)
-    arel (3.0.2)
-    awesome_print (1.1.0)
+    addressable (2.3.6)
+    ansi (1.5.0)
+    arel (3.0.3)
+    awesome_print (1.6.1)
     builder (3.0.4)
-    cobweb (1.0.4)
+    cobweb (1.0.25)
       addressable
       awesome_print
       haml
       json
-      namespaced_redis
       nokogiri
       redis
-      resque
-      rspec
+      redis-namespace
       sinatra
-      thin
+      slop (~> 3.4)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
-    coffee-script (2.2.0)
+    coffee-script (2.3.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.4.0)
-    daemons (1.1.9)
-    diff-lcs (1.1.3)
+    coffee-script-source (1.9.0)
+    cohesion (1.0.3)
+      cobweb
+      ptools
     erubis (2.7.0)
-    eventmachine (1.0.0)
-    execjs (1.4.0)
-      multi_json (~> 1.0)
-    haml (3.1.7)
-    hike (1.2.1)
-    i18n (0.6.1)
+    execjs (2.2.2)
+    haml (4.0.6)
+      tilt
+    hike (1.2.3)
+    i18n (0.7.0)
     journey (1.0.4)
-    jquery-rails (2.1.4)
+    jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.7.6)
+    json (1.8.2)
     mail (2.4.4)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.19)
-    multi_json (1.5.0)
-    namespaced_redis (1.0.4)
-      redis
-    nokogiri (1.5.6)
-    polyglot (0.3.3)
-    ptools (1.2.2)
-    rack (1.4.4)
+    mime-types (1.25.1)
+    mini_portile (0.6.2)
+    minitest (4.7.5)
+    mono_logger (1.1.0)
+    multi_json (1.10.1)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    polyglot (0.3.5)
+    ptools (1.3.2)
+    rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
-    rack-protection (1.3.2)
+    rack-protection (1.5.3)
       rack
-    rack-ssl (1.3.2)
+    rack-ssl (1.3.4)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (3.2.11)
       actionmailer (= 3.2.11)
@@ -108,55 +101,46 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rake (10.0.3)
-    rdoc (3.12)
+    rake (10.4.2)
+    rdoc (3.12.2)
       json (~> 1.4)
-    redis (3.0.2)
-    redis-namespace (1.2.1)
-      redis (~> 3.0.0)
-    resque (1.23.0)
+    redis (3.2.0)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
       multi_json (~> 1.0)
-      redis-namespace (~> 1.0)
+      redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    rspec (2.12.0)
-      rspec-core (~> 2.12.0)
-      rspec-expectations (~> 2.12.0)
-      rspec-mocks (~> 2.12.0)
-    rspec-core (2.12.2)
-    rspec-expectations (2.12.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.12.1)
-    sass (3.2.5)
+    sass (3.4.10)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    sinatra (1.3.3)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
-      tilt (~> 1.3, >= 1.3.3)
-    sprockets (2.2.2)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slop (3.6.0)
+    sprockets (2.2.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.7)
-    thin (1.5.0)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
-    thor (0.16.0)
-    tilt (1.3.3)
-    treetop (1.4.12)
+    sqlite3 (1.3.10)
+    thor (0.19.1)
+    tilt (1.4.1)
+    treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    turn (0.9.6)
+    turn (0.9.7)
       ansi
-    tzinfo (0.3.35)
-    uglifier (1.3.0)
+      minitest (~> 4)
+    tzinfo (0.3.42)
+    uglifier (2.7.0)
       execjs (>= 0.3.0)
-      multi_json (~> 1.0, >= 1.0.2)
+      json (>= 1.8.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
 
@@ -166,7 +150,7 @@ PLATFORMS
 DEPENDENCIES
   cobweb
   coffee-rails
-  cohesion!
+  cohesion
   jquery-rails
   rails (= 3.2.11)
   resque


### PR DESCRIPTION
### What is up?

This PR fixes the issue #2. The [Gemfile](https://github.com/stewartmckee/cobweb_sample/blob/master/Gemfile#L23) has a gem pointing to a a local path and it was removed.
Also to make a `bundle install` runs, I had to `bundle updade`.
